### PR TITLE
Add SECRET_CACHE_DURATION_NOTFOUND config

### DIFF
--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -115,6 +115,10 @@ spec:
             - name: CONCOURSE_SECRET_CACHE_DURATION
               value: {{ .Values.concourse.web.secretCacheDuration | quote }}
             {{- end }}
+            {{- if .Values.concourse.web.secretCacheDurationNotFound }}
+            - name: CONCOURSE_SECRET_CACHE_DURATION_NOTFOUND
+              value: {{ .Values.concourse.web.secretCacheDurationNotFound | quote }}
+            {{- end }}
             {{- if .Values.concourse.web.secretCacheEnabled }}
             - name: CONCOURSE_SECRET_CACHE_ENABLED
               value: {{ .Values.concourse.web.secretCacheEnabled | quote }}


### PR DESCRIPTION
Config added in [#4009](https://github.com/concourse/concourse/pull/4009)

Fixes the sad red box in CI: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-check-helm-params/builds/2925

Signed-off-by: Denise Yu <dyu@pivotal.io>